### PR TITLE
added fastlane for specific queries

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,10 @@ import createDataLoaders from "./datasourceLoader";
 import { v4 as uuid } from "uuid";
 import isbot from "isbot";
 import { parseTestToken } from "./utils/testUserStore";
+import isFastLaneQuery, {
+  fastLaneMiddleware,
+  getFastLane,
+} from "./utils/fastLane";
 
 // this is a quick-fix for macOS users, who get an EPIPE error when starting fbi-api
 process.stdout.on("error", function (err) {
@@ -82,6 +86,8 @@ promExporterApp.listen(9599, () => {
     next();
   });
 
+  app.post("/:profile/graphql", fastLaneMiddleware);
+
   // Middleware that monitors performance of those GraphQL queries
   // which specify a monitor name.
   app.post("/:profile/graphql", async (req, res, next) => {
@@ -124,6 +130,7 @@ promExporterApp.listen(9599, () => {
         hasUniqueId: !!req.user?.uniqueId,
         accessTokenHash,
         isTestToken: req.isTestToken,
+        fastLane: req.fastLane,
       });
       // monitorName is added to context/req in the monitor resolver
       if (req.monitorName) {
@@ -174,6 +181,7 @@ promExporterApp.listen(9599, () => {
       req.parsedQuery = graphQLParams.query
         .replace(/\n/g, " ")
         .replace(/\s+/g, " ");
+      req.queryDocument = document;
 
       // Check if query is introspection query
       req.isIntrospectionQuery = isIntrospectionQuery(ast);
@@ -284,6 +292,22 @@ promExporterApp.listen(9599, () => {
 
     // Set incomming query complexity
     req.queryComplexity = getQueryComplexity({ query, variables, schema });
+
+    // check if the query allows for fast lane
+    req.fastLane =
+      !req.isIntrospectionQuery && isFastLaneQuery(req.queryDocument, schema);
+
+    if (req.fastLane) {
+      req.fastLaneKey = JSON.stringify({
+        query,
+        variables,
+        profile: req.profile,
+      });
+      const fastLaneRes = await getFastLane(req.fastLaneKey);
+      if (fastLaneRes) {
+        return res.send(fastLaneRes);
+      }
+    }
 
     const handler = createHandler({
       schema,

--- a/src/utils/fastLane.js
+++ b/src/utils/fastLane.js
@@ -1,0 +1,193 @@
+import { set, get } from "../datasources/redis.datasource";
+
+const { visit } = require("graphql");
+
+// 10 minutes
+const TIME_TO_LIVE_SECONDS = 60 * 10;
+
+// These are the only types that are allowed for fast lane
+// Nothing user related can be in here
+const ALLOWED_TYPES = {
+  Boolean: true,
+  String: true,
+  DateTime: true,
+  BookMarkResponse: true,
+  Int: true,
+  BookMark: true,
+  UserSubscriptions: true,
+  BranchResult: true,
+  Branch: true,
+  AgencyType: true,
+  Manifestation: true,
+  ManifestationTitles: true,
+  Work: true,
+  Creator: true,
+  MaterialType: true,
+  Cover: true,
+  Role: true,
+  Translation: true,
+  GeneralMaterialType: true,
+  GeneralMaterialTypeCode: true,
+  SpecificMaterialType: true,
+
+  EntityQueryResult: true,
+  Entity: true,
+  FieldNodeLangcode: true,
+  FieldNodeNotificationFieldNotificationText: true,
+  Inspiration: true,
+  Categories: true,
+  Category: true,
+  SuggestResponse: true,
+  Suggestion: true,
+  SuggestionType: true,
+  CategoryResult: true,
+  WorkTitles: true,
+  WorkType: true,
+  Manifestations: true,
+  Identifier: true,
+  IdentifierType: true,
+  Languages: true,
+  Language: true,
+  PhysicalDescription: true,
+  Edition: true,
+  PublicationYear: true,
+  HostPublication: true,
+  AccessType: true,
+  Access: true,
+  AccessUrlType: true,
+  FictionNonfiction: true,
+  FictionNonfictionCode: true,
+  Audience: true,
+  ChildOrAdult: true,
+  ChildOrAdultCode: true,
+  SchoolUse: true,
+  Range: true,
+  Note: true,
+  NoteType: true,
+  Relations: true,
+  TableOfContent: true,
+  SubjectContainer: true,
+  Subject: true,
+  SubjectType: true,
+  Series: true,
+  SerieWork: true,
+  Universe: true,
+  NumberInSeries: true,
+  RecommendationResponse: true,
+  Recommendation: true,
+  ManifestationParts: true,
+  ManifestationPart: true,
+  Classification: true,
+  Localizations: true,
+  holdingAgency: true,
+  holdingsItem: true,
+  Shelfmark: true,
+};
+
+/**
+ * Collect all the return types that are requested in query
+ */
+function getAllTypesFromQuery(document, schema) {
+  const types = schema.getTypeMap();
+  const visitedTypes = {};
+  function getRealType(type) {
+    while (type?.type) {
+      type = type.type;
+    }
+    return type?.name?.value;
+  }
+  let currentType = [types.Query];
+
+  const namedObjectVisitor = {
+    enter(node) {
+      if (node.typeCondition?.name?.value) {
+        currentType = [types[node.typeCondition?.name?.value]];
+
+        return;
+      }
+      if (
+        node.name &&
+        node.kind === "Field" &&
+        currentType[currentType.length - 1]?.getFields
+      ) {
+        const type = getRealType(
+          currentType[currentType.length - 1].getFields()[node?.name?.value]
+            ?.astNode?.type
+        );
+        if (type) {
+          node.visited = true;
+          visitedTypes[type] = true;
+          //   console.log("enter field:", node?.name?.value, type, currentType);
+          currentType.push(types[type]);
+        }
+      }
+    },
+    leave(node) {
+      if (node.typeCondition?.name?.value) {
+        currentType = [types.Query];
+
+        return;
+      }
+      if (node.visited) {
+        currentType.pop();
+      }
+    },
+  };
+  visit(document, namedObjectVisitor);
+  return visitedTypes;
+}
+/**
+ * Check if the query allows for fast lane
+ */
+export default function isFastLaneQuery(document, schema) {
+  try {
+    const requestedTypes = getAllTypesFromQuery(document, schema);
+
+    return Object.keys(requestedTypes).every((type) => ALLOWED_TYPES[type]);
+  } catch (e) {
+    return false;
+  }
+}
+
+/**
+ * Set in Redis
+ */
+export function setFastLane(key, obj) {
+  return set(key, TIME_TO_LIVE_SECONDS, obj);
+}
+
+/**
+ * Get from Redis
+ */
+export async function getFastLane(key) {
+  return (await get(key))?.val;
+}
+
+/**
+ * Collects fast lane results and puts in Redis
+ */
+export function fastLaneMiddleware(req, res, next) {
+  var oldWrite = res.write,
+    oldEnd = res.end;
+
+  var chunks = [];
+
+  res.write = function (chunk, encoding) {
+    chunks.push(Buffer.from(chunk, encoding));
+
+    oldWrite.apply(res, arguments);
+  };
+
+  res.end = function (chunk, encoding) {
+    if (req.fastLane) {
+      if (chunk) chunks.push(Buffer.from(chunk, encoding));
+
+      var body = Buffer.concat(chunks).toString("utf8");
+      setFastLane(req.fastLaneKey, body);
+    }
+
+    oldEnd.apply(res, arguments);
+  };
+
+  next();
+}

--- a/src/utils/json.js
+++ b/src/utils/json.js
@@ -4,34 +4,36 @@
  * Prevents large JSON structures from blocking the event loop
  * should improve FBI-API concurrency
  */
-import yj from "yieldable-json";
+// import yj from "yieldable-json";
 
 /**
  * Parse json asynchronously
  */
 export async function parseJSON(str) {
-  return new Promise((resolve, reject) => {
-    yj.parseAsync(str, (err, data) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(data);
-      }
-    });
-  });
+  return JSON.parse(str);
+  //   return new Promise((resolve, reject) => {
+  //     yj.parseAsync(str, (err, data) => {
+  //       if (err) {
+  //         reject(err);
+  //       } else {
+  //         resolve(data);
+  //       }
+  //     });
+  //   });
 }
 
 /**
  * Stringify json asynchronously
  */
 export async function stringifyJSON(obj) {
-  return new Promise((resolve, reject) => {
-    yj.stringifyAsync(obj, (err, data) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(data);
-      }
-    });
-  });
+  return JSON.stringify(obj);
+  //   return new Promise((resolve, reject) => {
+  //     yj.stringifyAsync(obj, (err, data) => {
+  //       if (err) {
+  //         reject(err);
+  //       } else {
+  //         resolve(data);
+  //       }
+  //     });
+  //   });
 }


### PR DESCRIPTION
det er lidt tricky at finde alle typer i en query, da det skal sammenholdes med schema, men tror jeg har fået det til.

så hvis man laver en query, som kun bruger typer som vi har tilladt til "fast lane", så bliver hele svaret cachet i redis - så næste gang vil den ikke komme ind i resolverne.