### PR TITLE
corrected the cs cqlfilter search so that it actually uses the correc…

### DIFF
--- a/src/__tests__/__snapshots__/schematransform.test.js.snap
+++ b/src/__tests__/__snapshots__/schematransform.test.js.snap
@@ -259,13 +259,13 @@ type Query {
   work(id: String, faust: String, pid: String, oclc: String, language: LanguageCodeEnum): Work
   works(id: [String!], faust: [String!], pid: [String!], oclc: [String!], language: LanguageCodeEnum): [Work]!
   search(q: SearchQueryInput!, filters: SearchFiltersInput, search_exact: Boolean): SearchResponse!
-  complexSearch(cql: String!, filters: ComplexSearchFiltersInput, cqlfilters: ComplexSearchCQLFiltersInput, facets: ComplexSearchFacetsInput): ComplexSearchResponse!
+  complexSearch(cql: String!, filters: ComplexSearchFiltersInput, cqlfilter: ComplexSearchCQLFiltersInput, facets: ComplexSearchFacetsInput): ComplexSearchResponse!
   linkCheck: LinkCheckService!
 
   \\"\\"\\"
   ComplexFacets is for internal use only - there is no limit on how many facets are allowed to extract
   \\"\\"\\"
-  complexFacets(cql: String!, filters: ComplexSearchFiltersInput, cqlfilters: ComplexSearchCQLFiltersInput, facets: ComplexSearchFacetsInput): ComplexFacetResponse!
+  complexFacets(cql: String!, filters: ComplexSearchFiltersInput, cqlfilter: ComplexSearchCQLFiltersInput, facets: ComplexSearchFacetsInput): ComplexFacetResponse!
   localSuggest(
     \\"\\"\\"The query to get suggestions from\\"\\"\\"
     q: String!
@@ -766,7 +766,7 @@ input ComplexSearchFiltersInput {
 \\"\\"\\"CQL based filters. Mutually exclusive with ComplexSearchFiltersInput.\\"\\"\\"
 input ComplexSearchCQLFiltersInput {
   \\"\\"\\"A CQL expression used to filter the search result.\\"\\"\\"
-  CQLFilterQuery: String
+  cqlfilterquery: String
 }
 
 enum CSHoldingsStatusEnum {
@@ -5513,7 +5513,7 @@ type Query {
   work(id: String, faust: String, pid: String, oclc: String, language: LanguageCodeEnum): Work
   works(id: [String!], faust: [String!], pid: [String!], oclc: [String!], language: LanguageCodeEnum): [Work]!
   search(q: SearchQueryInput!, filters: SearchFiltersInput, search_exact: Boolean): SearchResponse!
-  complexSearch(cql: String!, filters: ComplexSearchFiltersInput, cqlfilters: ComplexSearchCQLFiltersInput, facets: ComplexSearchFacetsInput): ComplexSearchResponse!
+  complexSearch(cql: String!, filters: ComplexSearchFiltersInput, cqlfilter: ComplexSearchCQLFiltersInput, facets: ComplexSearchFacetsInput): ComplexSearchResponse!
   linkCheck: LinkCheckService!
   localSuggest(
     \\"\\"\\"The query to get suggestions from\\"\\"\\"
@@ -5619,7 +5619,7 @@ input ComplexSearchFiltersInput {
 \\"\\"\\"CQL based filters. Mutually exclusive with ComplexSearchFiltersInput.\\"\\"\\"
 input ComplexSearchCQLFiltersInput {
   \\"\\"\\"A CQL expression used to filter the search result.\\"\\"\\"
-  CQLFilterQuery: String
+  cqlfilterquery: String
 }
 
 enum CSHoldingsStatusEnum {

--- a/src/datasources/complexSearch/complexFacets.datasource.js
+++ b/src/datasources/complexSearch/complexFacets.datasource.js
@@ -16,7 +16,7 @@ const { url, ttl, prefix, teamLabel } = config.datasources.complexFacets;
  * Search via complex search
  */
 export async function load(
-  { cql, profile, filters, cqlfilters, facets, facetLimit },
+  { cql, profile, filters, cqlfilter, facets, facetLimit },
   context
 ) {
   const body = {
@@ -26,7 +26,7 @@ export async function load(
       profile: profile.name,
     },
     filters: filters,
-    cqlfilters: cqlfilters,
+    cqlfilter: cqlfilter,
     facets: prefixFacets(facets || []),
     facetLimit: facetLimit,
     trackingId: context?.trackingId,

--- a/src/datasources/complexSearch/complexFacetsWithLimit.datasource.js
+++ b/src/datasources/complexSearch/complexFacetsWithLimit.datasource.js
@@ -13,7 +13,7 @@ const { url, ttl, prefix, teamLabel } = config.datasources.complexsearch;
  * Search via complex search
  */
 export async function load(
-  { cql, profile, filters, cqlfilters, facets, facetLimit },
+  { cql, profile, filters, cqlfilter, facets, facetLimit },
   context
 ) {
   const body = {
@@ -23,7 +23,7 @@ export async function load(
       profile: profile.name,
     },
     filters: filters,
-    cqlfilters: cqlfilters,
+    cqlfilter: cqlfilter,
     facets: prefixFacets(facets || []),
     facetLimit: facetLimit,
     trackingId: context?.trackingId,

--- a/src/datasources/complexSearch/complexsearch.datasource.js
+++ b/src/datasources/complexSearch/complexsearch.datasource.js
@@ -7,7 +7,7 @@ const { url, ttl, prefix, teamLabel } = config.datasources.complexsearch;
  * Search via complex search
  */
 export async function load(
-  { cql, offset, limit, profile, filters, cqlfilters, sort },
+  { cql, offset, limit, profile, filters, cqlfilter, sort },
   context
 ) {
   const body = {
@@ -18,7 +18,7 @@ export async function load(
       profile: profile.name,
     },
     filters: filters,
-    cqlfilters: cqlfilters,
+    cqlfilter: cqlfilter,
     trackingId: context?.trackingId,
     includeFilteredPids: true,
     ...(sort && { sort: sort }),

--- a/src/schema/complexsearch.js
+++ b/src/schema/complexsearch.js
@@ -72,7 +72,7 @@ input ComplexSearchCQLFiltersInput {
   """
   A CQL expression used to filter the search result.
   """
-  CQLFilterQuery: String
+  cqlfilterquery: String
 }
 
 enum CSHoldingsStatusEnum {
@@ -241,7 +241,7 @@ function setPost(parent, context, args) {
     cql: parent.cql,
     profile: context.profile,
     filters: parent.filters,
-    cqlfilters: parent.cqlfilters,
+    cqlfilter: parent.cqlfilter,
     facets: parent?.facets?.facets,
     facetLimit: parent?.facets?.facetLimit,
     includeFilteredPids: parent?.includeFilteredPids || false,

--- a/src/schema/root.js
+++ b/src/schema/root.js
@@ -40,12 +40,12 @@ type Query {
   work(id: String, faust: String, pid: String, oclc: String, language: LanguageCodeEnum): Work @complexity(value: 5)
   works(id: [String!], faust: [String!], pid: [String!], oclc:[String!], language: LanguageCodeEnum): [Work]! @complexity(value: 5, multipliers: ["id", "pid", "faust", "oclc"])
   search(q: SearchQueryInput!, filters: SearchFiltersInput, search_exact: Boolean): SearchResponse!
-  complexSearch(cql: String!, filters: ComplexSearchFiltersInput, cqlfilters: ComplexSearchCQLFiltersInput, facets: ComplexSearchFacetsInput): ComplexSearchResponse!
+  complexSearch(cql: String!, filters: ComplexSearchFiltersInput, cqlfilter: ComplexSearchCQLFiltersInput, facets: ComplexSearchFacetsInput): ComplexSearchResponse!
   linkCheck: LinkCheckService! @complexity(value: 10, multipliers: ["urls"])
   """
   ComplexFacets is for internal use only - there is no limit on how many facets are allowed to extract
   """
-  complexFacets(cql: String!, filters: ComplexSearchFiltersInput, cqlfilters: ComplexSearchCQLFiltersInput, facets: ComplexSearchFacetsInput): ComplexFacetResponse!
+  complexFacets(cql: String!, filters: ComplexSearchFiltersInput, cqlfilter: ComplexSearchCQLFiltersInput, facets: ComplexSearchFacetsInput): ComplexFacetResponse!
 
   localSuggest(
     """
@@ -377,21 +377,21 @@ export const resolvers = {
       return args;
     },
     async complexSearch(parent, args, context, info) {
-      if (args.filters && args.cqlfilters) {
+      if (args.filters && args.cqlfilter) {
         return {
           "hitcount": 0,
           "works": [],
-          "errorMessage": "The 'filters' and 'cqlfilters' arguments are mutually exclusive — provide only one.",
+          "errorMessage": "The 'filters' and 'cqlfilter' arguments are mutually exclusive — provide only one.",
         };
       }
       return args;
     },
     async complexFacets(parent, args, context, info) {
-      if (args.filters && args.cqlfilters) {
+      if (args.filters && args.cqlfilter) {
         return {
           "hitcount": 0,
           "works": [],
-          "errorMessage": "The 'filters' and 'cqlfilters' arguments are mutually exclusive — provide only one.",
+          "errorMessage": "The 'filters' and 'cqlfilter' arguments are mutually exclusive — provide only one.",
         };
       }
       return args;


### PR DESCRIPTION
…t format

This is should correspond with the following curl 
`curl -sS -X POST "http://localhost:24080/api/v1/cqlquery"   -H "Content-Type: application/json"   -d '{"cqlQuery": "phrase.genreandform=romaner AND publicationyear=\"2014\"","searchProfile": {  "agency": "190101",  "profile": "bibdk21"},"cqlfilter": {"cqlfilterquery":"(agencyid=710100 AND status=onshelf)" },"trackingId": "heste"}'  | jq `

Note -->
,"cqlfilter": {"cqlfilterquery":"(agencyid=710100 AND status=onshelf)" }



